### PR TITLE
Update firebase-ui-auth to 6.2.1, remove firebase-auth

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,4 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.firebaseui:firebase-ui-auth:6.2.1'
     implementation 'com.facebook.android:facebook-android-sdk:5.5.1'
-    implementation('com.twitter.sdk.android:twitter:3.3.0@aar') {
-        transitive = true
-    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,8 +41,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.firebaseui:firebase-ui-auth:4.3.1'
-    implementation 'com.google.firebase:firebase-auth:19.0.0'
+    implementation 'com.firebaseui:firebase-ui-auth:6.2.1'
     implementation 'com.facebook.android:facebook-android-sdk:5.5.1'
     implementation('com.twitter.sdk.android:twitter:3.3.0@aar') {
         transitive = true


### PR DESCRIPTION
```
FirebaseUI libraries have the following transitive dependencies on the Firebase SDK:

firebase-ui-auth
|--- com.google.firebase:firebase-auth
|--- com.google.android.gms:play-services-auth
```


https://github.com/firebase/FirebaseUI-Android/blob/e9df5b55a5e83cea037f61188ce6dca3179a86d5/README.md#compatibility-with-firebase--google-play-services-libraries